### PR TITLE
Hotfix: Logger became a singleton in the library dir (and not under factory).

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -1,4 +1,5 @@
 const factory = require('../lib/factory')
+const logger = require('../lib/logger')
 const table = require('table')
 
 exports.command = 'list [search]'
@@ -13,7 +14,6 @@ exports.builder = {
 
 exports.handler = (argv) => {
   const registry = factory.ExtensionRegistry.create()
-  const logger = factory.Logger.create()
 
   const term = (argv.search || '').toString()
 


### PR DESCRIPTION
## Description
Changes the `require` location in the command/list.js's logger.

## Checklist for success
- [ ] This change isn't already implemented by a pending pull request
- [ ] This change is a child commit of a reasonably recent commit in the **master** branch 
    * Requests need not be a single commit, but should be a linear sequence of commits (i.e. no merge commits in your PR)
- [ ] All tests pass locally (see [the testing section](https://github.com/azure/platform-chaos-cli/blob/master/README.md#testing) for more info)
- [ ] All New behaviors or major functional changes have tests
